### PR TITLE
port full PSF code of conduct from python.org

### DIFF
--- a/docs/pypi.org/Code-of-Conduct.md
+++ b/docs/pypi.org/Code-of-Conduct.md
@@ -25,4 +25,4 @@ For any report that involves the above admins/moderators, email
 conduct-wg@python.org instead.
 
 [Python Packaging Authority]: https://github.com/pypa/
-[PSF Code of Conduct]: https://www.python.org/psf/conduct/
+[PSF Code of Conduct]: ../../python.org/code-of-conduct/

--- a/docs/python.org/code-of-conduct/Enforcement-Procedures.md
+++ b/docs/python.org/code-of-conduct/Enforcement-Procedures.md
@@ -1,0 +1,259 @@
+---
+source: https://www.python.org/psf/conduct/enforcement/
+---
+# Python Software Foundation Code of Conduct Working Group Enforcement Procedures
+
+This document summarizes the procedures the Python Software Foundation Code of Conduct work group uses to enforce the Code of Conduct.
+
+# Summary of processes
+
+When the work group receives a report of a possible Code of Conduct violation, it will:
+
+ 0. Acknowledge the receipt of the report.
+ 1. Evaluate conflicts of interest.
+ 2. Call a meeting of work group members without a conflict of interest.
+ 3. Evaluate the reported incident.
+ 4. Propose a behavioral modification plan.
+ 5. Propose consequences for the reported behavior.
+ 6. Vote on behavioral modification plan and consequences for the reported person.
+ 7. Contact online community administrators/moderators to approve the behavioral modification plan and consequences.
+ 8. Follow up with the reported person.
+ 9. Decide further responses.
+ 10. Follow up with the reporter.
+
+# Acknowledge the report
+
+Reporters should receive an emailed acknowledgment of the receipt of their report within 24 hours.
+
+# Conflict of interest policy
+
+Examples of conflicts of interest include:
+
+ * The reporter or reported person is your manager
+ * You have a romantic or platonic relationship with either the reporter or the reported person. It's fine to participate if they are an acquaintance.
+ * The reporter or reported person is your metamour. (This is a term used in the poly community; the short definition is [here](https://www.urbandictionary.com/define.php?term=Metamour), and a longer description is [here](https://solopoly.net/2012/09/29/whats-a-metamour-on-my-terms/)).
+ * The reporter or reported person is your family member
+ * The reporter or reported person is your direct client
+ * The reporter or reported person is someone you work closely with. This could be someone on your team or someone who works on the same project as you.
+ * The reporter or reported person is a maintainer who regularly reviews your contributions
+
+Committee members do not need to state why they have a conflict of interest, only that one exists. Other work group members should not ask why the person has a conflict of interest.
+
+Anyone who has a conflict of interest will remove themselves from the discussion of the incident, and recluse themselves from voting on a response to the report.
+
+# Evaluating a report
+
+## Jurisdiction
+
+ * *Is this a Code of Conduct violation?* Is this behavior on our list of inappropriate behavior? Is it borderline inappropriate behavior? Does it violate our community norms?
+ * *Did this occur in a space that is within our Code of Conduct's scope?* If the incident occurred outside the community, but a community member's mental health or physical safety may be negatively impacted if no action is taken, the incident may be in scope. Private conversations in community spaces are also in scope.
+
+## Impact
+
+ * *Did this incident occur in a private conversation or in a public space?* Incidents that all community members can see will have more negative impact.
+ * *Does this behavior negatively impact a marginalized group in our community?* Is the reporter a person from a marginalized group in our community? How is the reporter being negatively impacted by the reported person's behavior? Are members of the marginalized group likely to disengage with the community if no action was taken on this report?
+ * *Does this incident involve a community leader?* Community members often look up to community leaders to set the standard of acceptable behavior.
+
+## Risk
+
+ * *Does this incident include sexual harrasment?*
+ * *Does this pose a safety risk?* Does the behavior put a person's physical safety at risk? Will this incident severely negatively impact someone's mental health?
+ * *Is there a risk of this behavior being repeated?* Does the reported person understand why their behavior was inappropriate? Is there an established pattern of behavior from past reports?
+
+Reports which involve higher risk or higher impact may face more severe consequences than reports which involve lower risk or lower impact.
+
+# Propose a behavioral modification plan
+
+The work group will determine a concrete behavioral modification plan that ensures the inappropriate behavior is not repeated.  The work group will also discuss what actions may need to be taken if the reported person does not agree to the behavioral modification plan.
+
+What follows are examples of possible behavioral modification plans for incidents that occur in online spaces under the scope of this Code of Conduct. This behavioral modification list is not inclusive, and the Python Software Foundation Code of Conduct work group reserves the right to take any action it deems necessary.
+
+ * Requiring that the reported person not use specific language
+ * Requiring that the reported person not join in on specific types of discussions
+ * Requiring that the reported person not send private messages to a community member
+ * Requiring that the reported person not join specific communication channels
+ * Removing the reported person from administrator or moderator rights to community infrastructure
+ * Removing a volunteer from their duties and responsibilities
+ * Removing a person from leadership of relevant organizations
+ * Removing a person from membership of relevant organizations
+
+# Propose consequences
+
+What follows are examples of possible consequences to an incident report. This consequences list is not inclusive, and the Python Software Foundation Code of Conduct work group reserves the right to take any action it deems necessary.
+
+Possible private responses to an incident include:
+
+ * Nothing, if the behavior was determined to not be a Code of Conduct violation
+ * A verbal or emailed warning
+ * A final warning
+ * Temporarily removing the reported person from the online community
+ * Permanently removing the reported person from the online community
+ * Publishing an account of the incident
+
+# Work group vote
+
+Some work group members may have a conflict of interest and may be excluded from discussions of a particular incident report. Excluding those members, decisions on the behavioral modification plans and consequences will be determined by a two-thirds majority vote of the Python Software Foundation Code of Conduct work group.
+
+# Administrators/moderators approval
+
+Once the work group has approved the behavioral modification plans and consequences, they will communicate the recommended response to the administrators/moderators of the online community. The work group should not state who reported this incident. They should attempt to anonymize any identifying information from the report.
+
+Administrators/moderators are required to respond back with whether they accept the recommended response to the report. If they disagree with the recommended response, they should provide a detailed response or additional context as to why they disagree. Administrators/moderators are encouraged to respond within a week. 
+
+In cases where the administrators/moderators disagree on the suggested resolution for a report, the Python Software Foundation Code of Conduct work group may choose to notify the Python Software Foundation board.
+
+# Follow up with the reported person
+
+The Python Software Foundation Code of Conduct work group will work with online community administrators/moderators to draft a response to the reported person. The email should contain:
+
+ * A description of the person's behavior in neutral language
+ * The negative impact of that behavior
+ * A concrete behavioral modification plan
+ * Any consequences of their behavior
+
+The work group should not state who reported this incident. They should attempt to anonymize any identifying information from the report. The reported person should be discouraged from contacting the reporter to discuss the report. If they wish to apologize to the reporter, the work group can accept the apology on behalf of the reporter.
+
+# Decide further responses
+
+If the reported person provides additional context, the Python Software Foundation Code of Conduct work group may need to re-evaluate the behavioral modification plan and consequences.
+
+# Follow up with the reporter
+
+A person who makes a report should receive a follow up email stating what action was taken in response to the report. If the work group decided no response was needed, they should provide an email explaining why it was not a Code of Conduct violation. Reports that are not made in good faith (such as "reverse sexism" or "reverse racism") may receive no response.
+
+The follow up email should be sent no later than one week after the receipt of the report. If deliberation or follow up with the reported person takes longer than one week, the work group should send a status email to the reporter.
+
+# Documentation and Privacy Policies
+
+Depending on how the Code of Conduct committee is set up, there may be different places where information about Code of Conduct reports may be accessible:
+
+ * Personal email of Code of Conduct committee members
+ * Archives of committee mailing lists
+ * Logs from committee online chats
+ * Shared online documents, such as Google Docs or Next Cloud documents
+
+In all cases, documents and notes should only be available to committee members who do not have a conflict of interest for the report. This requires communities to choose documentation tools that will meet their privacy needs.
+
+## Committee shared email address
+
+Code of Conduct committees need to be able to be reached by one email address. It is recommended that the committee use an alias which forwards email to individual members.
+
+Using a mailing list is not recommended. This is because mailing lists typically archive all emails. This means new committee members gain access to all past archives. They can deliberately or accidentally see past reports where they have a conflict of interest. In order to prevent potential conflicts of interest, it is recommended to not have a mailing list archive.
+
+## Committee online discussion
+
+A Code of Conduct committee may have an online, real-time discussion forum, such as Slack, Zulip, or IRC. If the online chat platform allows, it is recommended to set the committee channel to have past history not be available to new committee members who join the channel.
+
+When a report comes in and a discussion needs to happen in an online space, care needs to be taken to avoid conflicts of interest. In the committee chat channel, state 'We have a report that involves [REPORTED PERSON]'. Do not say who was the reporter or who were witnesses if the report was sent to an individual committee member. Ask which committee members do not have a conflict of interest. Add those committee members to a group discussion, separate from the committee channel. If a committee member does not respond, do not add them to the new group discussion. If a committee member finds they have a conflict of interest because of who reported the incident or who witnessed it, they should recluse themselves from the discussion.
+
+Committee members should not use bots or IRC bouncers to log the group discussions. All documentation of discussions and decisions should be put in online, shared documentation.
+
+If no online real-time discussion forum is used, committee members without a conflict of interest will discuss the case on a separate email thread. If no committee member has a conflict of interest, and the committee email is an alias, the committee may reply to the alias to discuss the issues.
+
+## Shared Documentation
+
+The Code of Conduct committee should keep two types of shared documents:
+
+ * A spreadsheet with the status of open and closed cases
+ * A separate document for each report
+
+### Status Spreadsheet
+
+The spreadsheet with status of open and closed cases should have the following format:
+
+<table>
+    <thead>
+        <tr>
+            <th>Safety risk?</th>
+            <th>Risk of repeating?</th>
+            <th>Status</th>
+            <th>Code Name</th>
+            <th>Date &amp; Time</th>
+            <th>Actions needed</th>
+            <th>Resolution</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>Yes</td>
+            <td>Yes</td>
+            <td>Ongoing</td>
+            <td>home shelf</td>
+            <td>07/07 8:30am and 07/08 12:30pm</td>
+            <td>Team on the lookout for reported person</td>
+            <td>Temporary ban for the remainder of the event, reevaluate attendance for next year</td>
+        </tr>
+        <tr>
+            <td>No</td>
+            <td>Maybe</td>
+            <td>Resolved</td>
+            <td>stunned bulb</td>
+            <td>07/07 8:00pm</td>
+            <td>-</td>
+            <td>Verbal warning</td>
+        </tr>
+    </tbody>
+</table>
+
+Keep resolutions and notes vague enough that enforcement team members with a conflict of interest don't know the details of the incident. Use gender neutral language when describing the reported person in the spreadsheet.
+
+### Report Documentation
+
+Each report should be assigned a code name, using an [online random phrase generator](http://watchout4snakes.com/wo4snakes/Random/RandomPhrase). The code name should be used in the document's title. Only committee members without a conflict of interest should have access to the report documentation.
+
+Report documents should include:
+
+ * A summary of a verbal report, or the text of an emailed report. Use neutral, non-judgmental words to describe the behavior. Where possible, separate out the behavior of the reported person and the impact on the reporter.
+ * A summary of committee discussions, including whether the report is in scope
+ * Proposed behavioral modification plan
+ * Proposed consequences for the reported behavior
+ * A summary of verbal discussions, or the text of email discussions with community moderators, administrators, registration, or other event organizers about the proposed consequences and behavioral modification plan
+ * A summary of verbal discussions, or the text of email discussions with the reported person
+ * The text that was sent to follow up with the reporter
+
+All discussion summaries should include dates that they took place.
+
+### Privacy Concerns
+
+There are some common privacy pitfalls to online tools like Google Docs. Make sure to always share the document with committee members who don't have a conflict of interest, rather than turning link sharing on. This prevents people outside of the committee from accessing the documents.
+
+Another common issue is that when a folder is shared with the whole committee, even if a person doesn't have edit or view access to an individual report, they can still see the document's title. This can give information away, such as the person who made the report. Some communities use initials in the report title instead. That can still reveal information, and it makes it hard to talk about report status in public spaces (such as an event). The committee may want to assign a code name to each report, and reference that name in the report title and status spreadsheet. You can use an [online random phrase generator](http://watchout4snakes.com/wo4snakes/Random/RandomPhrase) to create the code name.
+
+When on-boarding new committee members, they should be provided with a list of names of people who have been reported in a Code of Conduct incident. The new committee member should state whether they have any conflicts of interest with reviewing documentation for those cases. If not, they will be given edit access to the report documents.
+
+# Changes to Code of Conduct
+
+When discussing a change to the Python community Code of Conduct or enforcement policies, the Python Software Foundation Code of Conduct work group will follow this decision-making process:
+
+* **Brainstorm options.** Work group members should discuss any relevant context and brainstorm a set of possible options. It is important to provide constructive feedback without getting side-tracked from the main question. Brainstorming should be limited to 3-7 days maximum.
+* **Vote.** Proposed changes to the Code of Conduct will be decided by a two-thirds majority of all voting members of the Code of Conduct work group. Work group members are listed in the [work group charter](https://wiki.python.org/psf/ConductWG/Charter). Currently active voting members are listed below.
+* **Board Vote.** Once a working draft is in place for the Code of Conduct and procedures, the Code of Conduct work group shall provide the PSF board with a draft of the changes. The PSF board will vote on the changes at a board meeting.
+
+## Current list of voting members
+
+Brett Cannon
+Carol Willing
+Ewa Jodlowska
+Jackie Kazil
+Jeff Triplett
+Lorena Mesa
+Philip James
+Rami Chowdhury
+Trey Hunner
+Van Lindberg
+
+## Advisers
+
+Advisers to the PSF Code of Conduct work group have access to the work group mailing list, but are not voting members.
+
+Anwesha Das
+Maricela Sanchez Miranda
+Naomi Ceder
+Thomas Wouters
+
+# Attribution
+
+ * The [PyCon Code of Conduct](https://us.pycon.org/2018/about/code-of-conduct/) is licensed under a [Creative Commons Attribution 3.0 Unported License](http://creativecommons.org/licenses/by/3.0/).
+ * Ada Initiative's guide titled "[Conference anti-harassment/Responding to Reports](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Responding_to_reports)" is licensed under a [Creative Commons Attribution 3.0 Unported License](http://creativecommons.org/licenses/by/3.0/)
+ * Audrey Eschright of [Safety First PDX](http://safetyfirstpdx.org/) provided the impact vs risk assessment framework, which is licensed under a [Creative Commons Attribution Share-Alike 3.0 Unported License](http://creativecommons.org/licenses/by-sa/3.0/) by Audrey Eschright of [Safety First PDX](http://safetyfirstpdx.org/)
+ * [Code of Conduct template](https://github.com/sagesharp/code-of-conduct-template/) was created by [Otter Tech](https://otter.technology/code-of-conduct-training) and is licensed under a [Creative Commons Attribution 3.0 Unported License](http://creativecommons.org/licenses/by/3.0/)

--- a/docs/python.org/code-of-conduct/Procedures-for-Reporting-Incidents.md
+++ b/docs/python.org/code-of-conduct/Procedures-for-Reporting-Incidents.md
@@ -6,7 +6,7 @@ source: https://www.python.org/psf/conduct/reporting/
 
 **If you believe someone is in physical danger, including from themselves**, the most important thing is to get that person help. Please contact the appropriate crisis number, non-emergency number, or police number. If you are in a PSF-sponsored conference or meeting, you can consult with a volunteer or staff member to help find an appropriate number.
 
-If you believe someone has violated the [PSF Code of Conduct](/psf/conduct/), we encourage you to report it. If you are unsure whether the incident is a violation, or whether the space where it happened is covered by the Code of Conduct, we encourage you to still report it. We are fine with receiving reports where we decide to take no action for the sake of creating a safer space.
+If you believe someone has violated the [PSF Code of Conduct](../) we encourage you to report it. If you are unsure whether the incident is a violation, or whether the space where it happened is covered by the Code of Conduct, we encourage you to still report it. We are fine with receiving reports where we decide to take no action for the sake of creating a safer space.
 
 Each PSF-controlled meeting or online forum should have a designated moderator or Code of Conduct point of contact.  Larger gatherings, like conferences, may have several people to contact. Specific information should be available for each PSF-affiliated gathering, online or off. 
 
@@ -58,13 +58,13 @@ In some cases we may determine that a public statement will need to be made. If 
 
 ## Report Handling Procedure
 
-When you make a report to an incident responder, they will gather information about the incident according to the Python Software Foundation [Procedure For Incident Response](/psf/conduct/enforcement).
+When you make a report to an incident responder, they will gather information about the incident according to the Python Software Foundation [Procedure For Incident Response](../Enforcement-Procedures).
 
 After an incident responder takes the report, they will immediately consult with the Code of Conduct Working Group, unless there is a conflict of interest, in which case any non-interested parties will be contacted. 
 
 If the incident is ongoing and needs to be immediately addressed, any lead incident responder may take appropriate action to ensure the safety of everyone involved. If the situation requires it, this may take the form of a referral to an appropriate non-PSF agency, including the local police. The PSF is not equipped to handle emergency situations.
 
-If the incident is less urgent, the report will be discussed by the Code of Conduct Working Group will meet to determine an appropriate response. Examples of possible incident responses are outlined in the PSF [Procedure For Incident Response](/psf/conduct/enforcement).
+If the incident is less urgent, the report will be discussed by the Code of Conduct Working Group will meet to determine an appropriate response. Examples of possible incident responses are outlined in the PSF [Procedure For Incident Response](../Enforcement-Procedures).
 
 Before any large in-person gathering conference, staff will have a mandatory meeting where incident response procedures will be outlined. After the conference, all incident responders will attend a debriefing session with the lead responders to discuss all incidents and determine any necessary follow-up actions.
 

--- a/docs/python.org/code-of-conduct/Procedures-for-Reporting-Incidents.md
+++ b/docs/python.org/code-of-conduct/Procedures-for-Reporting-Incidents.md
@@ -1,0 +1,89 @@
+---
+source: https://www.python.org/psf/conduct/reporting/
+---
+
+# Python Software Foundation Community Member Procedure For Reporting Code of Conduct Incidents
+
+**If you believe someone is in physical danger, including from themselves**, the most important thing is to get that person help. Please contact the appropriate crisis number, non-emergency number, or police number. If you are in a PSF-sponsored conference or meeting, you can consult with a volunteer or staff member to help find an appropriate number.
+
+If you believe someone has violated the [PSF Code of Conduct](/psf/conduct/), we encourage you to report it. If you are unsure whether the incident is a violation, or whether the space where it happened is covered by the Code of Conduct, we encourage you to still report it. We are fine with receiving reports where we decide to take no action for the sake of creating a safer space.
+
+Each PSF-controlled meeting or online forum should have a designated moderator or Code of Conduct point of contact.  Larger gatherings, like conferences, may have several people to contact. Specific information should be available for each PSF-affiliated gathering, online or off. 
+
+If you find that you need to make a report, and you cannot find the appropriate Code of Conduct reporting contact, you may report to the PSF Code of Conduct email alias below. The PSF will handle your report. If this happens, please also mention that you could not find specific reporting information so that we can improve.
+
+*General PSF reporting procedure:*
+
+The best way to contact the PSF Code of Conduct working group is by email at **<conduct-wg@python.org>**. The members of the Code of Conduct Working Group who monitor this alias is listed at [LINK](https://wiki.python.org/psf/ConductWG/Charter#List_of_Participants.2FWho_we_are). 
+
+In the event of a [conflict of interest](#conflicts-of-interest), you may directly contact any of the lead incident responders:
+
+  * Deb Nicholson
+      * Python Software Foundation - Executive Director
+      * <deb@python.org>
+  * Łukasz Langa
+      * Python Software Foundation - Code of Conduct WG Chair
+      * <lukasz@python.org>
+  * Tania Allard
+      * Python Software Foundation Director
+      * <taniar.allard@gmail.com>
+  * Drew Winstel
+      * Python Code of Conduct WG Member
+      * <drew@defna.org>
+
+You can also contact any member of the Python Software Foundation [Board of Directors](https://www.python.org/psf/members/#board-of-directors) to make a report. Certain gatherings and online fora, will have additional lead responders for the purpose of helping address incidents in particular PSF-affiliated spaces. 
+
+## Report Data
+
+When you make a report via email or phone, please include:
+
+* Your contact info (so we can get in touch with you if we need to follow up)
+* Date and time of the incident
+* Location of incident
+* Whether the incident is ongoing
+* Description of the incident
+* Identifying information of the reported person: name, physical appearance, height, clothing, voice accent, identifying badge information such as company name, ribbons, or badge number
+* Additional circumstances surrounding the incident
+* Other people involved in or witnesses to the incident and their contact information or description
+
+Please provide as much information as possible.
+
+## Confidentiality
+
+**All reports will be kept confidential**. When we discuss incidents with people who are reported, we will anonymize details as much as we can to protect reporter privacy.
+
+However, some incidents happen in one-on-one interactions, and even if the details are anonymized, the reported person may be able to guess who made the report. If you have concerns about retaliation or your personal safety, please note those in your report. We still encourage you to report, so that we can support you while keeping our conference attendees safe. In some cases, we can compile several anonymized reports into a pattern of behavior, and take action on that pattern.
+
+In some cases we may determine that a public statement will need to be made. If that's the case, the identities of all victims and reporters will remain confidential unless those individuals instruct us otherwise.
+
+## Report Handling Procedure
+
+When you make a report to an incident responder, they will gather information about the incident according to the Python Software Foundation [Procedure For Incident Response](/psf/conduct/enforcement).
+
+After an incident responder takes the report, they will immediately consult with the Code of Conduct Working Group, unless there is a conflict of interest, in which case any non-interested parties will be contacted. 
+
+If the incident is ongoing and needs to be immediately addressed, any lead incident responder may take appropriate action to ensure the safety of everyone involved. If the situation requires it, this may take the form of a referral to an appropriate non-PSF agency, including the local police. The PSF is not equipped to handle emergency situations.
+
+If the incident is less urgent, the report will be discussed by the Code of Conduct Working Group will meet to determine an appropriate response. Examples of possible incident responses are outlined in the PSF [Procedure For Incident Response](/psf/conduct/enforcement).
+
+Before any large in-person gathering conference, staff will have a mandatory meeting where incident response procedures will be outlined. After the conference, all incident responders will attend a debriefing session with the lead responders to discuss all incidents and determine any necessary follow-up actions.
+
+## Following Up With Reporters
+
+Within one week of an incident report, a member of the Code of Conduct Working Group, or one of the lead responders, will follow up with the person who made the report and provided their contact information. The follow up may include:
+
+* An acknowledgment that the Code of Conduct responders discussed the situation
+* Whether or not the report was determined to be a violation of the Code of Conduct
+* What actions (if any) were taken to correcting the reporter behavior
+
+In some cases, the lead responders may need to ask additional questions about the incident in order to identify the reported person.
+
+## Conflicts of Interest
+
+If an incident responder has a conflict of interest for a report, they will recuse themselves from the discussion and handling of the incident. The incident documentation will not be available to them, and they will excuse themselves from any conversations involving handling the incident.
+
+Should more than two of the PSF lead incident responders need to recuse themselves, another PSF Board member will step in as a temporary lead incident responder.
+
+---
+
+This procedure was adapted from the PyCon US reporters guide, which was itself adapted from the Ada Initiative's guide titled "[Conference anti-harassment/Responding to Reports](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Responding_to_reports)”, the [Django Project reporting guidelines](https://www.djangoproject.com/conduct/reporting/) (CC BY 3.0), with additions by [Otter Tech](https://otter.technology/).

--- a/docs/python.org/code-of-conduct/index.md
+++ b/docs/python.org/code-of-conduct/index.md
@@ -1,7 +1,7 @@
 ---
 source: https://www.python.org/psf/conduct/
 ---
-# Code of Conduct
+# Python Software Foundation Code of Conduct
 
 The Python community is made up of members from around the globe with a diverse set of skills, personalities, and experiences. It is through these differences that our community experiences great successes and continued growth. When you're working with members of the community, this Code of Conduct will help steer your interactions and keep Python a positive, successful, and growing community.
 
@@ -103,13 +103,13 @@ Event organizers will enforce this code throughout the event. Each event is requ
 
 ### PSF Online Spaces
 
-This Code of Conduct applies to the following people online spaces:
+This Code of Conduct applies to the following online spaces:
 
  * The [python-ideas](https://mail.python.org/mailman/listinfo/python-ideas), [core-mentorship](https://mail.python.org/mm3/mailman3/lists/core-mentorship.python.org/), [python-dev](https://mail.python.org/mailman/listinfo/python-dev), [docs](https://mail.python.org/mailman/listinfo/docs) mailing lists
  * All other [mailing lists hosted on python.org](https://mail.python.org/mailman/listinfo)
  * Python Software Foundation Zulip chat server
  * Python Software Foundation hosted Discourse server [discuss.python.org](https://discuss.python.org/)
- * Code repositories, issue trackers, and pull requests made against any Python Software Foundation controlled GitHub organization.
+ * Code repositories, issue trackers, and pull requests made against any Python Software Foundation controlled GitHub organization
  * The python.org mercurial server [hg.python.org](https://hg.python.org/)
  * Any other online space administered by the Python Software Foundation
 

--- a/docs/python.org/code-of-conduct/index.md
+++ b/docs/python.org/code-of-conduct/index.md
@@ -57,7 +57,7 @@ No weapons are allowed at Python Software Foundation events. Weapons include but
 
 ### Consequences
 
-If a participant engages in behavior that violates this code of conduct, the Python community Code of Conduct team may take any action they deem appropriate, including warning the offender or expulsion from the community and community events with no refund of event tickets. The full list of consequences for inappropriate behavior is listed in the [Enforcement Procedures](/psf/conduct/enforcement).
+If a participant engages in behavior that violates this code of conduct, the Python community Code of Conduct team may take any action they deem appropriate, including warning the offender or expulsion from the community and community events with no refund of event tickets. The full list of consequences for inappropriate behavior is listed in the [Enforcement Procedures](Enforcement-Procedures).
 
 Thank you for helping make this a welcoming, friendly community for everyone.
 
@@ -137,9 +137,9 @@ If you believe that someone is violating the code of conduct, or have any other 
 
 ## Procedure for Handling Incidents
 
-[Community Member Procedure For Reporting Code of Conduct Incidents](/psf/conduct/reporting)
+[Python Software Foundation Community Member Procedure For Reporting Code of Conduct Incidents](Procedures-for-Reporting-Incidents)
 
-[Python Software Foundation Code of Conduct Working Group Enforcement Procedures](/psf/conduct/enforcement)
+[Python Software Foundation Code of Conduct Working Group Enforcement Procedures](Enforcement-Procedures)
 
 ## License
 


### PR DESCRIPTION
We'll redirect the following URLs after merge/deploy:

|python.org|Location|
|---|---|
| psf/archive/codeofconduct | https://policies.python.org/python.org/code-of-conduct/ |
| psf/codeofconduct | https://policies.python.org/python.org/code-of-conduct/ |
| psf/conduct | https://policies.python.org/python.org/code-of-conduct/ |
| psf/conduct/enforcement | https://policies.python.org/python.org/code-of-conduct/Enforcement-Procedures/ |
| psf/conduct/reporting | https://policies.python.org/python.org/code-of-conduct/Procedures-for-Reporting-Incidents/ |