### PR TITLE
Include changes to CoC after Board decision

### DIFF
--- a/docs/python.org/code-of-conduct/Enforcement-Procedures.md
+++ b/docs/python.org/code-of-conduct/Enforcement-Procedures.md
@@ -213,6 +213,15 @@ Report documents should include:
 
 All discussion summaries should include dates that they took place.
 
+### Ongoing Documentation of Event and Community Bans
+
+The Board Secretary and/or other persons or roles designated by a resolution of the Board ("maintainers") shall maintain a list of people who have been banned from Python Software Foundation-organized events including:
+
+* The effective date of their ban
+* The duration of their bans, or whether the ban is permanent.
+
+This list shall only be viewable by the maintainers.
+
 ### Privacy Concerns
 
 There are some common privacy pitfalls to online tools like Google Docs. Make sure to always share the document with committee members who don't have a conflict of interest, rather than turning link sharing on. This prevents people outside of the committee from accessing the documents.

--- a/docs/python.org/code-of-conduct/index.md
+++ b/docs/python.org/code-of-conduct/index.md
@@ -115,6 +115,7 @@ This Code of Conduct applies to the following online spaces:
 
 This Code of Conduct applies to the following people in official Python Software Foundation online spaces:
 
+ * PSF Members, including Fellows
  * admins of the online space
  * maintainers
  * reviewers


### PR DESCRIPTION
The PSF Board decided, and the COC WG unanimously approved, two changes to the CoC:

- explicitly listing PSF members (and Fellows in particular) as falling under the policy;
- establishing a log of community bans maintained by the Board secretary.

Łukasz,
on behalf of the PSF COC Working Group