### PR TITLE
Move "Best Practices" from the retired community-code-of-conduct repo

### DIFF
--- a/docs/python.org/code-of-conduct/Best-Practices.md
+++ b/docs/python.org/code-of-conduct/Best-Practices.md
@@ -1,0 +1,75 @@
+# Best practices guide for a Code of Conduct for events
+
+In this guide, we aim to provide a general guide and checklist for event organizers of what an effective code of conduct at a community-run event should be like. We also provide a general guide for how code of conduct reports should be handled and how to publish a transparency report after the event. We know that some of the suggestions in here will be difficult for smaller or newer events, so we hope that you will consider these suggestions as something to aspire to as your community grows.
+
+## What is the goal of a Code of Conduct (CoC) at an event?
+
+The goal of a code of conduct is to provide a handbook of how participants should behave at an event to provide a safe, inclusive, and welcoming environment for everyone at the event. It is to enforce certain expected behaviors and to inform how any unacceptable behavior will be handled and removed.
+
+It is our recommendation to gather and ensemble a CoC team as early as possible and empower your team to create an effective CoC. 
+
+## What does an effective CoC consist of?
+
+An effective CoC should have the following:
+
+- Expected behavior (e.g. respect each other, constructive discussion, etc)
+- Unacceptable behavior (e.g. verbal or physical abuse, discrimination, etc)
+- The potential consequences of unacceptable behavior (e.g. asking to stop the unacceptable behavior, being removed from participation, etc)
+- Scope of the CoC (e.g. at the event venue, online discussion platform run by the event, and at the official social events)
+
+## Enforcement needs to be spelled out
+
+- You should include information on how to report (email, phone, in-person, etc) and who to report to 
+- Reports are handled by an independent CoC team, and the community should know who the team members are, and how to reach them. 
+- We also recommended using a dedicated CoC email instead of personal emails. Many groups use a shared email so that committee members can take turns responding 
+- The CoC should include a description of the procedure for handling the reports and what kinds of incident response can be expected
+
+In addition to the previously mentioned points, we recommend including: 
+- Precise instructions on how to report and who to report to if there is a conflict of interest (for example, if a report is about a member of the CoC team or conference staff, the community should know where to make these kinds of reports)
+- If possible, include at least two direct reporting options of different genders for sensitive reports
+- Include emergency numbers (e.g. police, fire, building security, etc.)
+ 
+Examples of effective CoC:
+
+- https://www.python.org/psf/conduct/
+- https://2024.djangocon.us/conduct/
+
+This is our recommendation, local communities should adopt a CoC according to their local culture and laws.
+
+## Where should the CoC be located/announced?
+
+Make sure you have a CoC section on your website from the launch. 
+
+Before the event: make sure anyone interested in joining the event is aware of the CoC. This includes volunteers, attendees, speakers, and organizers. When someone registers to attend the event, make sure that they have read and agreed to follow the CoC. The CoC can be included on the registration page and there can be a checkbox to check to indicate acceptance.
+
+During the event: make sure all the attendees are aware of the CoC, are reminded to follow the CoC, and know how to report if there are any issues. Mentioning this information during the opening remarks, putting signage at the event venues, and/or putting the CoC reminder on the badges are all good ideas.
+
+For meetups, we encourage you to share the short version of CoC as well as a way of contact in opening/introduction slides with a reference to your website or additional material.
+
+For conferences and larger events, make sure to mention the CoC and how to reach out to the CoC committee on the introduction slide and make sure the information is accessible. 
+
+## How should you handle a CoC report?
+
+- A dedicated CoC committee/team is handling the report
+- Direct communication channel to the CoC team to report (no public channel)
+- Mention and clarify incident report procedures. It will be reassuring to know about confidentiality, how the reports are handled, and what to expect from the procedure. https://www.python.org/psf/conduct/reporting/
+- [PSF](https://www.python.org/psf/conduct/enforcement/) and [numfocus](https://numfocus.org/code-of-conduct/response-and-enforcement-events-meetups) incident report enforcement are good references among others 
+- Recommended workshop on CoC enforcement: https://otter.technology/code-of-conduct-training/
+
+## How should you publish a transparency report?
+
+Publishing a transparency report after the event concludes is a critical step for gaining the trust of the community and ensuring the community that any issues that have been reported have been handled in an appropriate manner. Make sure the transparency report does not include any sensitive information such as the names of the reporters and the reported people. A transparency report is a way to address what issues have arisen and how they have been resolved.
+
+## Resources
+
+CoC incidents can happen within the social and online channels of your event or your organization. Providing some materials to improve your team’s awareness and ability to respond effectively is a good idea. Here are some additional references: 
+
+https://discover-cookbook.numfocus.org/07_code_of_conduct.html
+
+https://otter.technology/code-of-conduct-training/
+
+https://gitlab.com/otter-tech/coc-incident-response-workshop/-/blob/master/incident-training-slides.pdf
+
+## Conclusion
+
+The best practices for running a Code of Conduct for an event are continually changing and improving. We encourage and welcome feedback, suggestions for improvement, and any additional experience from your events on what does and does not help. Please contact conduct-wg@python.org with any feedback. Suggestions made via GitHub pull requests, which are more substantive than spelling/grammar fixes will be discussed via an internal vote rather than a standard PR approval/rejection. The PSF Code of Conduct Working Group maintains this guide.


### PR DESCRIPTION
The document is moved verbatim from psf/community-code-of-conduct@64c98f93a7b4cb854cac3c070d5746fb67645337.