### PR TITLE
Update COC WG member list, correct typos

### DIFF
--- a/docs/python.org/code-of-conduct/Enforcement-Procedures.md
+++ b/docs/python.org/code-of-conduct/Enforcement-Procedures.md
@@ -1,6 +1,3 @@
----
-source: https://www.python.org/psf/conduct/enforcement/
----
 # Python Software Foundation Code of Conduct Working Group Enforcement Procedures
 
 This document summarizes the procedures the Python Software Foundation Code of Conduct work group uses to enforce the Code of Conduct.
@@ -119,13 +116,13 @@ If the reported person provides additional context, the Python Software Foundati
 
 # Follow up with the reporter
 
-A person who makes a report should receive a follow up email stating what action was taken in response to the report. If the work group decided no response was needed, they should provide an email explaining why it was not a Code of Conduct violation. Reports that are not made in good faith (such as "reverse sexism" or "reverse racism") may receive no response.
+A person who makes a report should receive a follow-up email stating what action was taken in response to the report. If the work group decided no response was needed, they should provide an email explaining why it was not a Code of Conduct violation. Reports that are not made in good faith (such as "reverse sexism" or "reverse racism") may receive no response.
 
-The follow up email should be sent no later than one week after the receipt of the report. If deliberation or follow up with the reported person takes longer than one week, the work group should send a status email to the reporter.
+The follow-up email should be sent no later than one week after the receipt of the report. If deliberation or follow-up with the reported person takes longer than one week, the work group should send a status email to the reporter.
 
 # Documentation and Privacy Policies
 
-Depending on how the Code of Conduct committee is set up, there may be different places where information about Code of Conduct reports may be accessible:
+Depending on how the Code of Conduct committee is set up, there may be different places where information about the Code of Conduct reports may be accessible:
 
  * Personal email of Code of Conduct committee members
  * Archives of committee mailing lists
@@ -136,7 +133,7 @@ In all cases, documents and notes should only be available to committee members 
 
 ## Committee shared email address
 
-Code of Conduct committees need to be able to be reached by one email address. It is recommended that the committee use an alias which forwards email to individual members.
+Code of Conduct committees need to be able to be reached by one email address. It is recommended that the committee use an alias that forwards email to individual members.
 
 Using a mailing list is not recommended. This is because mailing lists typically archive all emails. This means new committee members gain access to all past archives. They can deliberately or accidentally see past reports where they have a conflict of interest. In order to prevent potential conflicts of interest, it is recommended to not have a mailing list archive.
 
@@ -195,7 +192,7 @@ The spreadsheet with status of open and closed cases should have the following f
     </tbody>
 </table>
 
-Keep resolutions and notes vague enough that enforcement team members with a conflict of interest don't know the details of the incident. Use gender neutral language when describing the reported person in the spreadsheet.
+Keep resolutions and notes vague enough that enforcement team members with a conflict of interest don't know the details of the incident. Use gender-neutral language when describing the reported person in the spreadsheet.
 
 ### Report Documentation
 
@@ -240,16 +237,17 @@ When discussing a change to the Python community Code of Conduct or enforcement 
 
 ## Current list of voting members
 
+Tania Allard
 Brett Cannon
-Carol Willing
-Ewa Jodlowska
-Jackie Kazil
-Jeff Triplett
-Lorena Mesa
-Philip James
 Rami Chowdhury
-Trey Hunner
-Van Lindberg
+Jessica Greene
+Cheuk Ting Ho
+Tereza Iofciu
+Łukasz Langa
+Deb Nicholson
+Mojdeh Rastgoo
+Jeff Triplett
+Drew Winstel
 
 ## Advisers
 

--- a/docs/python.org/code-of-conduct/Procedures-for-Reporting-Incidents.md
+++ b/docs/python.org/code-of-conduct/Procedures-for-Reporting-Incidents.md
@@ -1,12 +1,8 @@
----
-source: https://www.python.org/psf/conduct/reporting/
----
-
 # Python Software Foundation Community Member Procedure For Reporting Code of Conduct Incidents
 
 **If you believe someone is in physical danger, including from themselves**, the most important thing is to get that person help. Please contact the appropriate crisis number, non-emergency number, or police number. If you are in a PSF-sponsored conference or meeting, you can consult with a volunteer or staff member to help find an appropriate number.
 
-If you believe someone has violated the [PSF Code of Conduct](../) we encourage you to report it. If you are unsure whether the incident is a violation, or whether the space where it happened is covered by the Code of Conduct, we encourage you to still report it. We are fine with receiving reports where we decide to take no action for the sake of creating a safer space.
+If you believe someone has violated the [PSF Code of Conduct](../), we encourage you to report it. If you are unsure whether the incident is a violation, or whether the space where it happened is covered by the Code of Conduct, we encourage you to still report it. We are fine with receiving reports where we decide to take no action for the sake of creating a safer space.
 
 Each PSF-controlled meeting or online forum should have a designated moderator or Code of Conduct point of contact.  Larger gatherings, like conferences, may have several people to contact. Specific information should be available for each PSF-affiliated gathering, online or off. 
 
@@ -14,7 +10,7 @@ If you find that you need to make a report, and you cannot find the appropriate 
 
 *General PSF reporting procedure:*
 
-The best way to contact the PSF Code of Conduct working group is by email at **<conduct-wg@python.org>**. The members of the Code of Conduct Working Group who monitor this alias is listed at [LINK](https://wiki.python.org/psf/ConductWG/Charter#List_of_Participants.2FWho_we_are). 
+The best way to contact the PSF Code of Conduct working group is by email at **<conduct-wg@python.org>**. The members of the Code of Conduct Working Group who monitor this alias are listed at [LINK](https://wiki.python.org/psf/ConductWG/Charter#List_of_Participants.2FWho_we_are).
 
 In the event of a [conflict of interest](#conflicts-of-interest), you may directly contact any of the lead incident responders:
 
@@ -31,7 +27,7 @@ In the event of a [conflict of interest](#conflicts-of-interest), you may direct
       * Python Code of Conduct WG Member
       * <drew@defna.org>
 
-You can also contact any member of the Python Software Foundation [Board of Directors](https://www.python.org/psf/members/#board-of-directors) to make a report. Certain gatherings and online fora, will have additional lead responders for the purpose of helping address incidents in particular PSF-affiliated spaces. 
+You can also contact any member of the Python Software Foundation [Board of Directors](https://www.python.org/psf/members/#board-of-directors) to make a report. Certain gatherings and online fora will have additional lead responders for the purpose of helping address incidents in particular PSF-affiliated spaces.
 
 ## Report Data
 


### PR DESCRIPTION
The member list is now in sync with the COC WG Charter here: https://wiki.python.org/psf/ConductWG/Charter

The typos were fixed in the old community-code-of-conduct repository but those fixes never got published on the website.