### PR TITLE
docs(pypi): disallow obfuscation

### DIFF
--- a/docs/pypi.org/Acceptable-Use-Policy.md
+++ b/docs/pypi.org/Acceptable-Use-Policy.md
@@ -47,6 +47,7 @@ We do not allow content or activity on PyPI that:
   policies;
 - inauthentic interactions, such as fake accounts and automated inauthentic
   activity;
+- uses obfuscation techniques to hide or mask functionality;
 - creation of or participation in secondary markets for the purpose of the
   proliferation of inauthentic activity;
 - using PyPI as a platform for propagating abuse on other platforms;


### PR DESCRIPTION
PEP541 spells out what "Invalid projects" are,
and that a project may be removed for meeting any of these criteria.

Refs: https://peps.python.org/pep-0541/#invalid-projects