### PR TITLE
Fix broken link to PSF Board of Directors page in Code of Conduct documentation

### DIFF
--- a/docs/python.org/code-of-conduct/Procedures-for-Reporting-Incidents.md
+++ b/docs/python.org/code-of-conduct/Procedures-for-Reporting-Incidents.md
@@ -27,7 +27,7 @@ In the event of a [conflict of interest](#conflicts-of-interest), you may direct
       * Python Code of Conduct WG Member
       * <drew@defna.org>
 
-You can also contact any member of the Python Software Foundation [Board of Directors](https://www.python.org/psf/members/#board-of-directors) to make a report. Certain gatherings and online fora will have additional lead responders for the purpose of helping address incidents in particular PSF-affiliated spaces.
+You can also contact any member of the Python Software Foundation [Board of Directors](https://www.python.org/psf/board/) to make a report. Certain gatherings and online fora will have additional lead responders for the purpose of helping address incidents in particular PSF-affiliated spaces.
 
 ## Report Data
 


### PR DESCRIPTION
### **Description for Pull Request:**
This pull request fixes a broken link in the `Procedures-for-Reporting-Incidents.md` file under the `policies/docs/python.org/code-of-conduct/` directory.

- The original link pointing to the PSF Board of Directors (`https://www.python.org/psf/members/#board-of-directors`) was still active but redirected to the PSF fellow roster page, which was not the intended destination.

- The link has been updated to the correct one: `https://www.python.org/psf/board/`, which directly points to the current Python Software Foundation Board of Directors page.


![Correction](https://github.com/user-attachments/assets/34ffadef-5afc-47a5-ba02-04b5a62cb129)
