### PR TITLE
Miscellaneous formatting fixes and small edits

### DIFF
--- a/docs/python.org/code-of-conduct/Best-Practices.md
+++ b/docs/python.org/code-of-conduct/Best-Practices.md
@@ -1,60 +1,60 @@
 # Best practices guide for a Code of Conduct for events
 
-In this guide, we aim to provide a general guide and checklist for event organizers of what an effective code of conduct at a community-run event should be like. We also provide a general guide for how code of conduct reports should be handled and how to publish a transparency report after the event. We know that some of the suggestions in here will be difficult for smaller or newer events, so we hope that you will consider these suggestions as something to aspire to as your community grows.
+In this guide, we aim to provide a general guide and checklist for event organizers of what an effective Code of Conduct (CoC) at a community-run event should be like. We also provide a general guide for how Code of Conduct reports should be handled and how to publish a transparency report after the event. We know that some of the suggestions in here will be difficult for smaller or newer events, so we hope that you will consider these suggestions as something to aspire to as your community grows.
 
 ## What is the goal of a Code of Conduct (CoC) at an event?
 
-The goal of a code of conduct is to provide a handbook of how participants should behave at an event to provide a safe, inclusive, and welcoming environment for everyone at the event. It is to enforce certain expected behaviors and to inform how any unacceptable behavior will be handled and removed.
+The goal of a CoC is to provide a handbook of how participants should behave at an event to provide a safe, inclusive, and welcoming environment for everyone at the event. It is to enforce certain expected behaviors and to inform how any unacceptable behavior will be handled and removed.
 
-It is our recommendation to gather and ensemble a CoC team as early as possible and empower your team to create an effective CoC. 
+It is our recommendation to gather and ensemble a CoC team as early as possible and empower your team to create an effective CoC.
 
 ## What does an effective CoC consist of?
 
 An effective CoC should have the following:
 
-- Expected behavior (e.g. respect each other, constructive discussion, etc)
-- Unacceptable behavior (e.g. verbal or physical abuse, discrimination, etc)
-- The potential consequences of unacceptable behavior (e.g. asking to stop the unacceptable behavior, being removed from participation, etc)
+- Expected behavior (e.g. respect each other, constructive discussion, etc.)
+- Unacceptable behavior (e.g. verbal or physical abuse, discrimination, etc.)
+- The potential consequences of unacceptable behavior (e.g. asking to stop the unacceptable behavior, being removed from participation, etc.)
 - Scope of the CoC (e.g. at the event venue, online discussion platform run by the event, and at the official social events)
 
 ## Enforcement needs to be spelled out
 
-- You should include information on how to report (email, phone, in-person, etc) and who to report to 
-- Reports are handled by an independent CoC team, and the community should know who the team members are, and how to reach them. 
-- We also recommended using a dedicated CoC email instead of personal emails. Many groups use a shared email so that committee members can take turns responding 
-- The CoC should include a description of the procedure for handling the reports and what kinds of incident response can be expected
+- You should include information on how to report (email, phone, in-person, etc.) and who to report to
+- Reports are handled by an independent CoC team, and the community should know who the team members are, and how to reach them.
+- We also recommended using a dedicated CoC email instead of personal emails. Many groups use a shared email so that committee members can take turns responding.
+- The CoC should include a description of the procedure for handling the reports and what kinds of incident response can be expected.
 
-In addition to the previously mentioned points, we recommend including: 
+In addition to the previously mentioned points, we recommend including:
 - Precise instructions on how to report and who to report to if there is a conflict of interest (for example, if a report is about a member of the CoC team or conference staff, the community should know where to make these kinds of reports)
 - If possible, include at least two direct reporting options of different genders for sensitive reports
 - Include emergency numbers (e.g. police, fire, building security, etc.)
- 
+
 Examples of effective CoC:
 
-- https://www.python.org/psf/conduct/
-- https://2024.djangocon.us/conduct/
+- [The PSF Code of Conduct](https://www.python.org/psf/conduct/)
+- [DjangoCon US Code of Conduct](https://2024.djangocon.us/conduct/)
 
 This is our recommendation, local communities should adopt a CoC according to their local culture and laws.
 
 ## Where should the CoC be located/announced?
 
-Make sure you have a CoC section on your website from the launch. 
+Make sure you have a CoC section on your website from the launch.
 
-Before the event: make sure anyone interested in joining the event is aware of the CoC. This includes volunteers, attendees, speakers, and organizers. When someone registers to attend the event, make sure that they have read and agreed to follow the CoC. The CoC can be included on the registration page and there can be a checkbox to check to indicate acceptance.
+**Before the event**: make sure anyone interested in joining the event is aware of the CoC. This includes volunteers, attendees, speakers, and organizers. When someone registers to attend the event, make sure that they have read and agreed to follow the CoC. The CoC can be included on the registration page and there can be a checkbox to check to indicate acceptance.
 
-During the event: make sure all the attendees are aware of the CoC, are reminded to follow the CoC, and know how to report if there are any issues. Mentioning this information during the opening remarks, putting signage at the event venues, and/or putting the CoC reminder on the badges are all good ideas.
+**During the event**: make sure all the attendees are aware of the CoC, are reminded to follow the CoC, and know how to report if there are any issues. Mentioning this information during the opening remarks, putting signage at the event venues, and/or putting the CoC reminder on the badges are all good ideas.
 
 For meetups, we encourage you to share the short version of CoC as well as a way of contact in opening/introduction slides with a reference to your website or additional material.
 
-For conferences and larger events, make sure to mention the CoC and how to reach out to the CoC committee on the introduction slide and make sure the information is accessible. 
+For conferences and larger events, make sure to mention the CoC and how to reach out to the CoC committee on the introduction slide and make sure the information is accessible.
 
 ## How should you handle a CoC report?
 
 - A dedicated CoC committee/team is handling the report
 - Direct communication channel to the CoC team to report (no public channel)
-- Mention and clarify incident report procedures. It will be reassuring to know about confidentiality, how the reports are handled, and what to expect from the procedure. https://www.python.org/psf/conduct/reporting/
-- [PSF](https://www.python.org/psf/conduct/enforcement/) and [numfocus](https://numfocus.org/code-of-conduct/response-and-enforcement-events-meetups) incident report enforcement are good references among others 
-- Recommended workshop on CoC enforcement: https://otter.technology/code-of-conduct-training/
+- Mention and clarify incident report procedures. It will be reassuring to know about confidentiality, how the reports are handled, and what to expect from the procedure. (See the [PSF CoC reporting procedures]( https://www.python.org/psf/conduct/reporting/) for an example)
+- [The PSF CoC enforcement procedures](https://www.python.org/psf/conduct/enforcement/) and [NumFOCUS incident response procedures](https://numfocus.org/code-of-conduct/response-and-enforcement-events-meetups) are good references among others
+- Recommended workshop on CoC enforcement: <https://otter.technology/code-of-conduct-training/>
 
 ## How should you publish a transparency report?
 
@@ -62,14 +62,14 @@ Publishing a transparency report after the event concludes is a critical step fo
 
 ## Resources
 
-CoC incidents can happen within the social and online channels of your event or your organization. Providing some materials to improve your team’s awareness and ability to respond effectively is a good idea. Here are some additional references: 
+CoC incidents can happen within the social and online channels of your event or your organization. Providing some materials to improve your team’s awareness and ability to respond effectively is a good idea. Here are some additional references:
 
-https://discover-cookbook.numfocus.org/07_code_of_conduct.html
+- <https://discover-cookbook.numfocus.org/07_code_of_conduct.html>
 
-https://otter.technology/code-of-conduct-training/
+- <https://otter.technology/code-of-conduct-training/>
 
-https://gitlab.com/otter-tech/coc-incident-response-workshop/-/blob/master/incident-training-slides.pdf
+- <https://gitlab.com/otter-tech/coc-incident-response-workshop/-/blob/master/incident-training-slides.pdf>
 
 ## Conclusion
 
-The best practices for running a Code of Conduct for an event are continually changing and improving. We encourage and welcome feedback, suggestions for improvement, and any additional experience from your events on what does and does not help. Please contact conduct-wg@python.org with any feedback. Suggestions made via GitHub pull requests, which are more substantive than spelling/grammar fixes will be discussed via an internal vote rather than a standard PR approval/rejection. The PSF Code of Conduct Working Group maintains this guide.
+The best practices for running a Code of Conduct for an event are continually changing and improving. We encourage and welcome feedback, suggestions for improvement, and any additional experience from your events on what does and does not help. Please contact <conduct-wg@python.org> with any feedback. Suggestions made via GitHub pull requests, which are more substantive than spelling/grammar fixes will be discussed via an internal vote rather than a standard PR approval/rejection. The PSF Code of Conduct Working Group maintains this guide.

--- a/docs/python.org/code-of-conduct/Enforcement-Procedures.md
+++ b/docs/python.org/code-of-conduct/Enforcement-Procedures.md
@@ -2,7 +2,7 @@
 
 This document summarizes the procedures the Python Software Foundation Code of Conduct work group uses to enforce the Code of Conduct.
 
-# Summary of processes
+## Summary of processes
 
 When the work group receives a report of a possible Code of Conduct violation, it will:
 
@@ -18,11 +18,11 @@ When the work group receives a report of a possible Code of Conduct violation, i
  9. Decide further responses.
  10. Follow up with the reporter.
 
-# Acknowledge the report
+## Acknowledge the report
 
 Reporters should receive an emailed acknowledgment of the receipt of their report within 24 hours.
 
-# Conflict of interest policy
+## Conflict of interest policy
 
 Examples of conflicts of interest include:
 
@@ -38,20 +38,20 @@ Committee members do not need to state why they have a conflict of interest, onl
 
 Anyone who has a conflict of interest will remove themselves from the discussion of the incident, and recluse themselves from voting on a response to the report.
 
-# Evaluating a report
+## Evaluating a report
 
-## Jurisdiction
+### Jurisdiction
 
  * *Is this a Code of Conduct violation?* Is this behavior on our list of inappropriate behavior? Is it borderline inappropriate behavior? Does it violate our community norms?
  * *Did this occur in a space that is within our Code of Conduct's scope?* If the incident occurred outside the community, but a community member's mental health or physical safety may be negatively impacted if no action is taken, the incident may be in scope. Private conversations in community spaces are also in scope.
 
-## Impact
+### Impact
 
  * *Did this incident occur in a private conversation or in a public space?* Incidents that all community members can see will have more negative impact.
  * *Does this behavior negatively impact a marginalized group in our community?* Is the reporter a person from a marginalized group in our community? How is the reporter being negatively impacted by the reported person's behavior? Are members of the marginalized group likely to disengage with the community if no action was taken on this report?
  * *Does this incident involve a community leader?* Community members often look up to community leaders to set the standard of acceptable behavior.
 
-## Risk
+### Risk
 
  * *Does this incident include sexual harassment?*
  * *Does this pose a safety risk?* Does the behavior put a person's physical safety at risk? Will this incident severely negatively impact someone's mental health?
@@ -59,7 +59,7 @@ Anyone who has a conflict of interest will remove themselves from the discussion
 
 Reports which involve higher risk or higher impact may face more severe consequences than reports which involve lower risk or lower impact.
 
-# Propose a behavioral modification plan
+## Propose a behavioral modification plan
 
 The work group will determine a concrete behavioral modification plan that ensures the inappropriate behavior is not repeated.  The work group will also discuss what actions may need to be taken if the reported person does not agree to the behavioral modification plan.
 
@@ -74,7 +74,7 @@ What follows are examples of possible behavioral modification plans for incident
  * Removing a person from leadership of relevant organizations
  * Removing a person from membership of relevant organizations
 
-# Propose consequences
+## Propose consequences
 
 What follows are examples of possible consequences to an incident report. This consequences list is not inclusive, and the Python Software Foundation Code of Conduct work group reserves the right to take any action it deems necessary.
 
@@ -87,19 +87,19 @@ Possible private responses to an incident include:
  * Permanently removing the reported person from the online community
  * Publishing an account of the incident
 
-# Work group vote
+## Work group vote
 
 Some work group members may have a conflict of interest and may be excluded from discussions of a particular incident report. Excluding those members, decisions on the behavioral modification plans and consequences will be determined by a two-thirds majority vote of the Python Software Foundation Code of Conduct work group.
 
-# Administrators/moderators approval
+## Administrators/moderators approval
 
 Once the work group has approved the behavioral modification plans and consequences, they will communicate the recommended response to the administrators/moderators of the online community. The work group should not state who reported this incident. They should attempt to anonymize any identifying information from the report.
 
-Administrators/moderators are required to respond back with whether they accept the recommended response to the report. If they disagree with the recommended response, they should provide a detailed response or additional context as to why they disagree. Administrators/moderators are encouraged to respond within a week. 
+Administrators/moderators are required to respond back with whether they accept the recommended response to the report. If they disagree with the recommended response, they should provide a detailed response or additional context as to why they disagree. Administrators/moderators are encouraged to respond within a week.
 
 In cases where the administrators/moderators disagree on the suggested resolution for a report, the Python Software Foundation Code of Conduct work group may choose to notify the Python Software Foundation board.
 
-# Follow up with the reported person
+## Follow up with the reported person
 
 The Python Software Foundation Code of Conduct work group will work with online community administrators/moderators to draft a response to the reported person. The email should contain:
 
@@ -110,17 +110,17 @@ The Python Software Foundation Code of Conduct work group will work with online 
 
 The work group should not state who reported this incident. They should attempt to anonymize any identifying information from the report. The reported person should be discouraged from contacting the reporter to discuss the report. If they wish to apologize to the reporter, the work group can accept the apology on behalf of the reporter.
 
-# Decide further responses
+## Decide further responses
 
 If the reported person provides additional context, the Python Software Foundation Code of Conduct work group may need to re-evaluate the behavioral modification plan and consequences.
 
-# Follow up with the reporter
+## Follow up with the reporter
 
 A person who makes a report should receive a follow-up email stating what action was taken in response to the report. If the work group decided no response was needed, they should provide an email explaining why it was not a Code of Conduct violation. Reports that are not made in good faith (such as "reverse sexism" or "reverse racism") may receive no response.
 
 The follow-up email should be sent no later than one week after the receipt of the report. If deliberation or follow-up with the reported person takes longer than one week, the work group should send a status email to the reporter.
 
-# Documentation and Privacy Policies
+## Documentation and Privacy Policies
 
 Depending on how the Code of Conduct committee is set up, there may be different places where information about the Code of Conduct reports may be accessible:
 
@@ -131,13 +131,13 @@ Depending on how the Code of Conduct committee is set up, there may be different
 
 In all cases, documents and notes should only be available to committee members who do not have a conflict of interest for the report. This requires communities to choose documentation tools that will meet their privacy needs.
 
-## Committee shared email address
+### Committee shared email address
 
 Code of Conduct committees need to be able to be reached by one email address. It is recommended that the committee use an alias that forwards email to individual members.
 
 Using a mailing list is not recommended. This is because mailing lists typically archive all emails. This means new committee members gain access to all past archives. They can deliberately or accidentally see past reports where they have a conflict of interest. In order to prevent potential conflicts of interest, it is recommended to not have a mailing list archive.
 
-## Committee online discussion
+### Committee online discussion
 
 A Code of Conduct committee may have an online, real-time discussion forum, such as Slack, Zulip, or IRC. If the online chat platform allows, it is recommended to set the committee channel to have past history not be available to new committee members who join the channel.
 
@@ -147,14 +147,14 @@ Committee members should not use bots or IRC bouncers to log the group discussio
 
 If no online real-time discussion forum is used, committee members without a conflict of interest will discuss the case on a separate email thread. If no committee member has a conflict of interest, and the committee email is an alias, the committee may reply to the alias to discuss the issues.
 
-## Shared Documentation
+### Shared Documentation
 
 The Code of Conduct committee should keep two types of shared documents:
 
  * A spreadsheet with the status of open and closed cases
  * A separate document for each report
 
-### Status Spreadsheet
+#### Status Spreadsheet
 
 The spreadsheet with status of open and closed cases should have the following format:
 
@@ -194,7 +194,7 @@ The spreadsheet with status of open and closed cases should have the following f
 
 Keep resolutions and notes vague enough that enforcement team members with a conflict of interest don't know the details of the incident. Use gender-neutral language when describing the reported person in the spreadsheet.
 
-### Report Documentation
+#### Report Documentation
 
 Each report should be assigned a code name, using an [online random phrase generator](http://watchout4snakes.com/wo4snakes/Random/RandomPhrase). The code name should be used in the document's title. Only committee members without a conflict of interest should have access to the report documentation.
 
@@ -210,7 +210,7 @@ Report documents should include:
 
 All discussion summaries should include dates that they took place.
 
-### Ongoing Documentation of Event and Community Bans
+#### Ongoing Documentation of Event and Community Bans
 
 The Board Secretary and/or other persons or roles designated by a resolution of the Board ("maintainers") shall maintain a list of people who have been banned from Python Software Foundation-organized events including:
 
@@ -219,7 +219,7 @@ The Board Secretary and/or other persons or roles designated by a resolution of 
 
 This list shall only be viewable by the maintainers.
 
-### Privacy Concerns
+#### Privacy Concerns
 
 There are some common privacy pitfalls to online tools like Google Docs. Make sure to always share the document with committee members who don't have a conflict of interest, rather than turning link sharing on. This prevents people outside of the committee from accessing the documents.
 
@@ -227,7 +227,7 @@ Another common issue is that when a folder is shared with the whole committee, e
 
 When on-boarding new committee members, they should be provided with a list of names of people who have been reported in a Code of Conduct incident. The new committee member should state whether they have any conflicts of interest with reviewing documentation for those cases. If not, they will be given edit access to the report documents.
 
-# Changes to Code of Conduct
+## Changes to Code of Conduct
 
 When discussing a change to the Python community Code of Conduct or enforcement policies, the Python Software Foundation Code of Conduct work group will follow this decision-making process:
 

--- a/docs/python.org/code-of-conduct/Procedures-for-Reporting-Incidents.md
+++ b/docs/python.org/code-of-conduct/Procedures-for-Reporting-Incidents.md
@@ -22,7 +22,7 @@ In the event of a [conflict of interest](#conflicts-of-interest), you may direct
       * <lukasz@python.org>
   * Tania Allard
       * Python Software Foundation Director
-      * <taniar.allard@gmail.com>
+      * <tania@python.org>
   * Drew Winstel
       * Python Code of Conduct WG Member
       * <drew@defna.org>

--- a/docs/python.org/code-of-conduct/Procedures-for-Reporting-Incidents.md
+++ b/docs/python.org/code-of-conduct/Procedures-for-Reporting-Incidents.md
@@ -10,7 +10,7 @@ If you find that you need to make a report, and you cannot find the appropriate 
 
 *General PSF reporting procedure:*
 
-The best way to contact the PSF Code of Conduct working group is by email at **<conduct-wg@python.org>**. The members of the Code of Conduct Working Group who monitor this alias are listed at [LINK](https://wiki.python.org/psf/ConductWG/Charter#List_of_Participants.2FWho_we_are).
+The best way to contact the PSF Code of Conduct working group is by email at **<conduct-wg@python.org>**. The members of the Code of Conduct Working Group who monitor this alias are listed in [the CoC WG charter](https://wiki.python.org/psf/ConductWG/Charter#List_of_Participants.2FWho_we_are).
 
 In the event of a [conflict of interest](#conflicts-of-interest), you may directly contact any of the lead incident responders:
 

--- a/docs/python.org/code-of-conduct/Procedures-for-Reporting-Incidents.md
+++ b/docs/python.org/code-of-conduct/Procedures-for-Reporting-Incidents.md
@@ -8,7 +8,7 @@ Each PSF-controlled meeting or online forum should have a designated moderator o
 
 If you find that you need to make a report, and you cannot find the appropriate Code of Conduct reporting contact, you may report to the PSF Code of Conduct email alias below. The PSF will handle your report. If this happens, please also mention that you could not find specific reporting information so that we can improve.
 
-*General PSF reporting procedure:*
+## General PSF reporting procedure
 
 The best way to contact the PSF Code of Conduct working group is by email at **<conduct-wg@python.org>**. The members of the Code of Conduct Working Group who monitor this alias are listed in [the CoC WG charter](https://wiki.python.org/psf/ConductWG/Charter#List_of_Participants.2FWho_we_are).
 

--- a/docs/python.org/code-of-conduct/Transparency-Report-Guidelines.md
+++ b/docs/python.org/code-of-conduct/Transparency-Report-Guidelines.md
@@ -42,4 +42,4 @@ If there was a post-conference survey asking attendees about their confidence in
 
 ## What **NOT** to include
 
-Make sure the transparency report does not include any sensitive information such as the names or any identifiable information of the reporters and the reported people. In the event that law enforcement was called, you should say they were called and not make further comments on the details as it could adversely affect official action. 
+Make sure the transparency report does not include any sensitive information such as the names or any identifiable information of the reporters and the reported people. In the event that law enforcement was called, you should say they were called and not make further comments on the details as it could adversely affect official action.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,6 +44,7 @@ nav:
           - "python.org/code-of-conduct/Best-Practices.md"
           - "python.org/code-of-conduct/Enforcement-Procedures.md"
           - "python.org/code-of-conduct/Procedures-for-Reporting-Incidents.md"
+          - "python.org/code-of-conduct/Transparency-Report-Guidelines.md"
   - "us.pycon.org":
       - "us.pycon.org/Privacy-Notice.md"
       - "Code of Conduct":


### PR DESCRIPTION
While having a read of our policies, I realised there were various edits needed so I am adding:

- Miscellaneous formatting fixes and small edits -> links were not being appropriately rendered, some links text was not descriptive enough (e.g. link)
- Update Tania's email -> use my Python.org email instead
- Fix headings order -> there should only be one H1 level heading (especially helpful for those using assistive tech)
- Add Transparency report guidelines to index -> This was merged back in May, but for whatever reason, it was not added to the config file, so it was not being rendered 
