### PR TITLE
chore/dx: make docker preview server stop immediately

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -4,6 +4,7 @@ services:
       context: .
     pull_policy: never
     command: mkdocs serve -a 0.0.0.0:8000 -f mkdocs.yml
+    stop_signal: SIGINT
     volumes:
       - ./.git:/opt/venv/src/.git:z
       - ./mkdocs.yml:/opt/venv/src/mkdocs.yml:z


### PR DESCRIPTION
setting this signal stops the development container immediately rather than waiting for a 10s timeout