### PR TITLE
Restore voting members list and remove broken wiki link

### DIFF
--- a/docs/python.org/code-of-conduct/Enforcement-Procedures.md
+++ b/docs/python.org/code-of-conduct/Enforcement-Procedures.md
@@ -238,7 +238,16 @@ When discussing a change to the Python community Code of Conduct or enforcement 
 
 ## Current list of voting members
 
-The list of members can be found [here](https://wiki.python.org/psf/ConductWG/Charter#List_of_Participants.2FWho_we_are). 
+* Rami Chowdhury
+* Jessica Greene
+* Cheuk Ting Ho
+* Jeremy Hylton
+* Deb Nicholson
+* Mojdeh Rastgoo
+* Jeff Triplett
+* Drew Winstel
+* Koti Vellanki
+* Monica Oyugi
 
 # Attribution
 


### PR DESCRIPTION
tl;dr We didn't know the wiki was going away so liking to the wiki doesn't make as much sense now. 

- Restores the inline voting members list that was replaced with a wiki link in #49
- The wiki link is no longer valid
- Removes former members (Tania Allard [leave], Tereza Iofciu) and the advisers section
